### PR TITLE
Update to 8.0.1: skip win32

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.0" %}
+{% set version = "8.0.1" %}
 
 package:
   name: proj
@@ -6,7 +6,7 @@ package:
 
 source:
   url: http://download.osgeo.org/proj/proj-{{ version }}.tar.gz
-  sha256: aa5d4b934450149a350aed7e5fbac880e2f7d3fa2f251c26cb64228f96a2109e
+  sha256: e0463a8068898785ca75dd49a261d3d28b07d0a88f3b657e8e0089e16a0375fa
 
 build:
   number: 0


### PR DESCRIPTION

Checklist
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Update dependencies to 8.0.1

It belongs to anaconda_affiliated_deps.

Skip win32 because test commands failed and don't run properly
And the way to install PROJ on Windows is to use the OSGeo4W software distribution https://proj.org/install.html#windows
<!--
Please add any other relevant info below:
-->
