### PR TITLE
In this change:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.1" %}
+{% set version = "8.2.1" %}
 
 package:
   name: proj
@@ -6,8 +6,9 @@ package:
 
 source:
   url: http://download.osgeo.org/proj/proj-{{ version }}.tar.gz
-  sha256: e0463a8068898785ca75dd49a261d3d28b07d0a88f3b657e8e0089e16a0375fa
+  sha256: 76ed3d0c3a348a6693dfae535e5658bbfd47f71cb7ff7eb96d9f12f7e068b1cf
   patches:
+    # Remove SQLite vesrion check from CMakeLists.txt. The version is pined below.
     - sqlite_check.patch
 
 build:
@@ -26,11 +27,11 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - sqlite
+    - sqlite >=3.11
     - libtiff
     - libcurl
   run:
-    - sqlite
+    - sqlite >=3.11
     - libtiff
     - libcurl
   run_constrained:
@@ -48,8 +49,12 @@ test:
 about:
   home: https://proj.org/
   license: MIT
+  license_family: MIT
   license_file: COPYING
   summary: Cartographic Projections and Coordinate Transformations Library
+  dev_url: https://github.com/OSGeo/PROJ
+  doc_url: https://proj.org/index.html
+  doc_src_url: https://github.com/OSGeo/PROJ/tree/master/docs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
In this change:
- Update upstream version from `8.0.1` to `8.2.1`.
- Document reason for patch file.
- Pin SQLite version to match `CMakeLists.txt` finds.

Reviewed conda-forge updates, no major differences.

SQLite pin:
https://github.com/OSGeo/PROJ/blob/deb1a5720fdfcd50d53c93ffb4011cacb36f2c89/CMakeLists.txt#L191

nlhomann_json pin:
https://github.com/OSGeo/PROJ/blob/8.2.1/CMakeLists.txt#L146
NOTE: We allow proj to use internal nlhomann_json. No need to include it.

libtiff, no version required:
https://github.com/OSGeo/PROJ/blob/8.2.1/CMakeLists.txt#L203

libcurl, no version required:
https://github.com/OSGeo/PROJ/blob/8.2.1/CMakeLists.txt#L223

Threads, not required:
https://github.com/OSGeo/PROJ/blob/8.2.1/CMakeLists.txt#L242




Review upstream issues: https://github.com/OSGeo/PROJ/issues
I did not notice any issues that looked like regresions from `8.0.1`.


Review the changelog: https://github.com/OSGeo/PROJ/releases
Lots of updates and bug fixes.

Note: this changelog is deprecated: https://github.com/OSGeo/PROJ/blob/8.2/ChangeLog


Local `osx-arm64` tests run and the change is small.