### PR TITLE
[PKG-3742] Update to 9.3.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,6 +6,7 @@ cmake -G "NMake Makefiles" ^
          -D CMAKE_C_FLAGS="/WX" ^
          -D CMAKE_CXX_FLAGS="/WX" ^
          -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+         -D NLOHMANN_JSON_ORIGIN=external ^
          %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,7 +19,6 @@ cd ..
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
-mkdir %ACTIVATE_DIR%
 if not exist %ACTIVATE_DIR% mkdir %ACTIVATE_DIR%
 if errorlevel 1 exit 1
 if not exist %DEACTIVATE_DIR% mkdir %DEACTIVATE_DIR%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,7 +9,6 @@ cmake -G "NMake Makefiles" ^
          -D CMAKE_CXX_FLAGS="/WX" ^
          -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
          -D NLOHMANN_JSON_ORIGIN="external" ^
-         -D USE_EXTERNAL_GTEST=ON ^
          %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,7 +6,7 @@ cmake -G "NMake Makefiles" ^
          -D CMAKE_C_FLAGS="/WX" ^
          -D CMAKE_CXX_FLAGS="/WX" ^
          -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-         -D NLOHMANN_JSON_ORIGIN=external ^
+         -D NLOHMANN_JSON_ORIGIN="external" ^
          %SRC_DIR%
 if errorlevel 1 exit 1
 
@@ -14,9 +14,6 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 cd ..
-
-del /F /Q %LIBRARY_PREFIX%\\share\\proj\\*.cmake
-if errorlevel 1 exit 1
 
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ cmake -G "NMake Makefiles" ^
          -D CMAKE_CXX_FLAGS="/WX" ^
          -D CMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
          -D NLOHMANN_JSON_ORIGIN="external" ^
+         -D USE_EXTERNAL_GTEST=ON ^
          %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,3 +1,5 @@
+@echo on
+
 mkdir build && cd build
 
 cmake -G "NMake Makefiles" ^
@@ -18,8 +20,9 @@ cd ..
 set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
 set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
 mkdir %ACTIVATE_DIR%
+if not exist %ACTIVATE_DIR% mkdir %ACTIVATE_DIR%
 if errorlevel 1 exit 1
-mkdir %DEACTIVATE_DIR%
+if not exist %DEACTIVATE_DIR% mkdir %DEACTIVATE_DIR%
 if errorlevel 1 exit 1
 
 copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\proj4-activate.bat

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,6 +17,7 @@ cmake ${CMAKE_ARGS} \
       -D CMAKE_INSTALL_LIBDIR=lib \
       -D EXE_SQLITE3=${EXE_SQLITE3} \
       -D NLOHMANN_JSON_ORIGIN="external" \
+      -D USE_EXTERNAL_GTEST=OFF \
       ${SRC_DIR}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $SRC_DIR
+
 mkdir -p build && cd build
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
@@ -14,6 +16,7 @@ cmake ${CMAKE_ARGS} \
       -D CMAKE_INSTALL_PREFIX=${PREFIX} \
       -D CMAKE_INSTALL_LIBDIR=lib \
       -D EXE_SQLITE3=${EXE_SQLITE3} \
+      -D NLOHMANN_JSON_ORIGIN="external" \
       ${SRC_DIR}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd $SRC_DIR
-
 mkdir -p build && cd build
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" != "1" ]]; then
@@ -17,7 +15,7 @@ cmake ${CMAKE_ARGS} \
       -D CMAKE_INSTALL_LIBDIR=lib \
       -D EXE_SQLITE3=${EXE_SQLITE3} \
       -D NLOHMANN_JSON_ORIGIN="external" \
-      -D USE_EXTERNAL_GTEST=OFF \
+      -D USE_EXTERNAL_GTEST=ON \
       ${SRC_DIR}
 
 make -j${CPU_COUNT} ${VERBOSE_CM}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,10 +20,22 @@ cmake ${CMAKE_ARGS} \
 
 make -j${CPU_COUNT} ${VERBOSE_CM}
 
-# skip tests on linux32 due to rounding error causing issues
-if [[ ! ${HOST} =~ .*linux.* ]] || [[ ! ${ARCH} == 32 ]]; then
-if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
+if [[ "${target_platform}" != osx-arm64 ]]; then
     ctest --output-on-failure
+else
+    # tolerance issue on osx-arm64
+    # -------------------------------------------------------------------------------
+    # Reading file '$SRC_DIR/test/gie/builtins.gie'
+    # -------------------------------------------------------------------------------
+    # proj=vandg a=6400000 over                                             
+    # -------------------------------------------------------------------------------
+    #      FAILURE in builtins.gie(7245):
+    #      roundtrip deviation: 0.320062 mm, expected: 0.250000 mm
+    # -------------------------------------------------------------------------------
+    # total: 2327 tests succeeded,  0 tests skipped,  1 tests FAILED!
+    # -------------------------------------------------------------------------------
+    ctest --output-on-failure || true
 fi
 fi
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,12 +20,8 @@ make -j${CPU_COUNT} ${VERBOSE_CM}
 
 # skip tests on linux32 due to rounding error causing issues
 if [[ ! ${HOST} =~ .*linux.* ]] || [[ ! ${ARCH} == 32 ]]; then
-if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
-if [[ "${target_platform}" != osx-* ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
     ctest --output-on-failure
-else
-    ctest --output-on-failure || true
-fi
 fi
 fi
 

--- a/recipe/define_OLD_BUGGY_REMQUO.patch
+++ b/recipe/define_OLD_BUGGY_REMQUO.patch
@@ -1,0 +1,11 @@
+--- proj-9.2.0.orig/src/tests/geodsigntest.c	2023-03-01 04:58:50.000000000 -0300
++++ proj-9.2.0/src/tests/geodsigntest.c	2023-03-02 13:59:56.543419844 -0300
+@@ -40,7 +40,7 @@
+  * serious (just a loss of accuracy).  If you're still using the buggy glibc,
+  * then define OLD_BUGGY_REMQUO to be 1.
+  */
+-#define OLD_BUGGY_REMQUO 0
++#define OLD_BUGGY_REMQUO 1
+ #endif
+ 
+ static const T wgs84_a = 6378137, wgs84_f = 1/298.257223563; /* WGS84 */

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
     - libtiff {{ libtiff }}
     - libcurl 7.88.1
     - nlohmann_json 3.11.2
+    - gtest 1.14.0
   run:
     # bounds through run_exports
     - sqlite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,12 +25,13 @@ requirements:
     - patch     # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - sqlite     # [build_platform != target_platform]
   host:
-    - sqlite
-    - libtiff
-    - libcurl
+    - sqlite {{ sqlite }}
+    - libtiff {{ libtiff }}
+    - libcurl 7.88.1
+    - nlohmann_json 3.11.2
   run:
+    # bounds through run_exports
     - sqlite
     - libtiff
     - libcurl
@@ -56,9 +57,12 @@ about:
   license_family: MIT
   license_file: COPYING
   summary: Cartographic Projections and Coordinate Transformations Library
+  description: |
+    PROJ is a generic coordinate transformation software that transforms geospatial 
+    coordinates from one coordinate reference system (CRS) to another. 
+    This includes cartographic projections as well as geodetic transformations.
   dev_url: https://github.com/OSGeo/PROJ
   doc_url: https://proj.org/index.html
-  doc_src_url: https://github.com/OSGeo/PROJ/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,14 @@
-{% set version = "8.2.1" %}
+{% set version = "9.3.1" %}
 
 package:
   name: proj
   version: {{ version }}
 
 source:
-  url: http://download.osgeo.org/proj/proj-{{ version }}.tar.gz
-  sha256: 76ed3d0c3a348a6693dfae535e5658bbfd47f71cb7ff7eb96d9f12f7e068b1cf
+  url: https://download.osgeo.org/proj/proj-{{ version }}.tar.gz
+  sha256: b0f919cb9e1f42f803a3e616c2b63a78e4d81ecfaed80978d570d3a5e29d10bc
   patches:
-    # Remove SQLite vesrion check from CMakeLists.txt. The version is pined below.
-    - sqlite_check.patch
+    - define_OLD_BUGGY_REMQUO.patch
 
 build:
   number: 0
@@ -26,12 +25,13 @@ requirements:
     - patch     # [not win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - sqlite     # [build_platform != target_platform]
   host:
-    - sqlite >=3.11
+    - sqlite
     - libtiff
     - libcurl
   run:
-    - sqlite >=3.11
+    - sqlite
     - libtiff
     - libcurl
   run_constrained:
@@ -42,6 +42,10 @@ test:
     - test -f ${PREFIX}/lib/libproj${SHLIB_EXT}  # [unix]
     - test ! -f ${PREFIX}/lib/libproj.a          # [unix]
     - if not exist %LIBRARY_LIB%\\proj.lib exit 1  # [win]
+    # should be the first CLI test to ensure cs2cs results don't change
+    # See https://github.com/conda-forge/proj.4-feedstock/pull/139
+    - >-
+      [[ $(echo 569704.57 4269024.67 | cs2cs EPSG:26915 +to EPSG:26715) == $(echo 569704.57 4269024.67 | cs2cs EPSG:26915 +to EPSG:26715) ]]  # [unix]
     - echo -105 40 | proj +proj=utm +zone=13 +ellps=WGS84
     - echo -117 30 | cs2cs +proj=latlong +datum=NAD27 +to +proj=latlong +datum=NAD83
     - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/
     - {{ pin_subpackage('proj', max_pin='x.x.x') }}
+  ignore_run_exports:
+    - gtest
 
 requirements:
   build:
@@ -30,7 +32,7 @@ requirements:
     - libtiff {{ libtiff }}
     - libcurl 7.88.1
     - nlohmann_json 3.11.2
-    - gtest 1.14.0
+    - gtest 1.14.0 # [unix]
   run:
     # bounds through run_exports
     - sqlite

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,12 +1,12 @@
 :: Store existing env vars and set to this conda env
 :: so other installs don't pollute the environment.
 
-@if defined PROJ_LIB (
-    set "_CONDA_SET_PROJ_LIB=%PROJ_LIB%"
+@if defined PROJ_DATA (
+    set "_CONDA_SET_PROJ_DATA=%PROJ_DATA%"
 )
-@set "PROJ_LIB=%CONDA_PREFIX%\Library\share\proj"
+@set "PROJ_DATA=%CONDA_PREFIX%\Library\share\proj"
 
-@if exist %CONDA_PREFIX%\Library\share\proj\copyright_and_licenses.csv (
+@if exist "%CONDA_PREFIX%\Library\share\proj\copyright_and_licenses.csv" (
     rem proj-data is installed because its license was copied over
     @set "PROJ_NETWORK=OFF"
 ) else (

--- a/recipe/scripts/activate.csh
+++ b/recipe/scripts/activate.csh
@@ -23,10 +23,3 @@ else
 endif
 
 setenv PROJ_NETWORK "ON"
-
-if ( -f "${CONDA_PREFIX}/share/proj/copyright_and_licenses.csv" ) then
-  # proj-data is installed because its license was copied over
-  setenv PROJ_NETWORK "OFF"
-else
-  setenv PROJ_NETWORK "ON"
-endif

--- a/recipe/scripts/activate.csh
+++ b/recipe/scripts/activate.csh
@@ -3,14 +3,23 @@
 # Store existing env vars and set to this conda env
 # so other installs don't pollute the environment.
 
-if ( $?PROJ_LIB ) then
-  setenv _CONDA_SET_PROJ_LIB "$PROJ_LIB"
+if ( $?PROJ_DATA ) then
+  setenv _CONDA_SET_PROJ_DATA "$PROJ_DATA"
 endif
 
 if ( -d "${CONDA_PREFIX}/share/proj" ) then
-  setenv PROJ_LIB "${CONDA_PREFIX}/share/proj"
+  setenv PROJ_DATA "${CONDA_PREFIX}/share/proj"
 else if ( -d "${CONDA_PREFIX}/Library/share/proj" ) then
-  setenv PROJ_LIB "${CONDA_PREFIX}/Library/share/proj"
+  setenv PROJ_DATA "${CONDA_PREFIX}/Library/share/proj"
+endif
+
+setenv PROJ_NETWORK "ON"
+
+if ( -f "${CONDA_PREFIX}/share/proj/copyright_and_licenses.csv" ) then
+  # proj-data is installed because its license was copied over
+  setenv PROJ_NETWORK "OFF"
+else
+  setenv PROJ_NETWORK "ON"
 endif
 
 setenv PROJ_NETWORK "ON"

--- a/recipe/scripts/activate.fish
+++ b/recipe/scripts/activate.fish
@@ -1,13 +1,20 @@
 #!/usr/bin/env fish
 
-if set -q PROJ_LIB
-  set -gx _CONDA_SET_PROJ_LIB "$PROJ_LIB"
+if set -q PROJ_DATA
+  set -gx _CONDA_SET_PROJ_DATA "$PROJ_DATA"
 end
 
 if test -d "$CONDA_PREFIX/share/proj"
-  set -gx PROJ_LIB "$CONDA_PREFIX/share/proj"
+  set -gx PROJ_DATA "$CONDA_PREFIX/share/proj"
 else if test -d "$CONDA_PREFIX/Library/share/proj"
-  set -gx PROJ_LIB "$CONDA_PREFIX/Library/share/proj"
+  set -gx PROJ_DATA "$CONDA_PREFIX/Library/share/proj"
+end
+
+if test -f "$CONDA_PREFIX/share/proj/copyright_and_licenses.csv"
+  # proj-data is installed because its license was copied over
+  set -gx PROJ_NETWORK "OFF"
+else
+  set -gx PROJ_NETWORK "ON"
 end
 
 if test -f "$CONDA_PREFIX/share/proj/copyright_and_licenses.csv"

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -3,15 +3,15 @@
 # Store existing env vars and set to this conda env
 # so other installs don't pollute the environment.
 
-if [ -n "${PROJ_LIB:-}" ]; then
-    export _CONDA_SET_PROJ_LIB=$PROJ_LIB
+if [ -n "${PROJ_DATA:-}" ]; then
+    export _CONDA_SET_PROJ_DATA=$PROJ_DATA
 fi
 
 
 if [ -d "${CONDA_PREFIX}/share/proj" ]; then
-  export "PROJ_LIB=${CONDA_PREFIX}/share/proj"
+  export "PROJ_DATA=${CONDA_PREFIX}/share/proj"
 elif [ -d "${CONDA_PREFIX}/Library/share/proj" ]; then
-  export PROJ_LIB="${CONDA_PREFIX}/Library/share/proj"
+  export PROJ_DATA="${CONDA_PREFIX}/Library/share/proj"
 fi
 
 if [ -f "${CONDA_PREFIX}/share/proj/copyright_and_licenses.csv" ]; then

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,8 +1,8 @@
 :: Restore previous GDAL env vars if they were set.
 
-@set "PROJ_LIB="
+@set "PROJ_DATA="
 @set "PROJ_NETWORK="
-@if defined _CONDA_SET_PROJ_LIB (
-  set "PROJ_LIB=%_CONDA_SET_PROJ_LIB%"
-  set "_CONDA_SET_PROJ_LIB="
+@if defined _CONDA_SET_PROJ_DATA (
+  set "PROJ_DATA=%_CONDA_SET_PROJ_DATA%"
+  set "_CONDA_SET_PROJ_DATA="
 )

--- a/recipe/scripts/deactivate.csh
+++ b/recipe/scripts/deactivate.csh
@@ -1,10 +1,10 @@
 #!/usr/bin/env csh
 
 # Restore previous env vars if they were set.
-unsetenv PROJ_LIB
+unsetenv PROJ_DATA
 unsetenv PROJ_NETWORK
 
-if ( $?_CONDA_SET_PROJ_LIB ) then
-    setenv PROJ_LIB "$_CONDA_SET_PROJ_LIB"
-    unsetenv _CONDA_SET_PROJ_LIB
+if ( $?_CONDA_SET_PROJ_DATA ) then
+    setenv PROJ_DATA "$_CONDA_SET_PROJ_DATA"
+    unsetenv _CONDA_SET_PROJ_DATA
 endif

--- a/recipe/scripts/deactivate.fish
+++ b/recipe/scripts/deactivate.fish
@@ -1,10 +1,10 @@
 #!/usr/bin/env fish
 
 # Restore previous env vars if they were set.
-set -e PROJ_LIB
+set -e PROJ_DATA
 set -e PROJ_NETWORK
 
-if set -q _CONDA_SET_PROJ_LIB
-    set -gx  PROJ_LIB "$_CONDA_SET_PROJ_LIB"
-    set -e _CONDA_SET_PROJ_LIB
+if set -q _CONDA_SET_PROJ_DATA
+    set -gx  PROJ_DATA "$_CONDA_SET_PROJ_DATA"
+    set -e _CONDA_SET_PROJ_DATA
 end

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Restore previous env vars if they were set.
-unset PROJ_LIB
+unset PROJ_DATA
 unset PROJ_NETWORK
 
-if [ -n "$_CONDA_SET_PROJ_LIB" ]; then
-    export PROJ_LIB=$_CONDA_SET_PROJ_LIB
-    unset _CONDA_SET_PROJ_LIB
+if [ -n "${_CONDA_SET_PROJ_DATA:-}" ]; then
+    export PROJ_DATA="${_CONDA_SET_PROJ_DATA}"
+    unset _CONDA_SET_PROJ_DATA
 fi


### PR DESCRIPTION
Why:
- The proj version pinned on the cbc is too old and has to be updated. We might as well get the latest proj available.

Changes:
- Update to 9.3.1 by merging changes from cf.
- add details on why tests are skipped on osx
- use our NLOHMANN_JSON
- use our gtest on unix (the downloaded version results in build errors on osx).

https://github.com/OSGeo/PROJ/tree/9.3.1
https://github.com/OSGeo/PROJ/blob/9.3.1/NEWS

note: PROJ_LIB is deprecated in favour or PROJ_DATA since 9.1.0, hence the change in activation scripts (see https://github.com/OSGeo/PROJ/pull/3253)