### PR TITLE
proj 9.3.1: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/475b812

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - sqlite {{ sqlite }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - libcurl {{ libcurl }}
     - nlohmann_json 3.11.2
     - gtest 1.14.0 # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [s390x]
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - define_OLD_BUGGY_REMQUO.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/
@@ -29,8 +29,8 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - sqlite {{ sqlite }}
-    - libtiff {{ libtiff }}
-    - libcurl 7.88.1
+    - libtiff 4.7.0
+    - libcurl {{ libcurl }}
     - nlohmann_json 3.11.2
     - gtest 1.14.0 # [unix]
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 1
+  skip: true  # [s390x]
   run_exports:
     # so name changes in bugfix revisions.  Pin to bugfix revision.
     #    https://abi-laboratory.pro/tracker/timeline/proj/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7597](https://anaconda.atlassian.net/browse/PKG-7597) 
- [Upstream repository](https://github.com/OSGeo/PROJ/tree/9.3.1)

### Explanation of changes:

- Bump the build number to 1
- Pin libtiff and libcurl in host

### Notes:

-

[PKG-7597]: https://anaconda.atlassian.net/browse/PKG-7597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ